### PR TITLE
chore(deps): update dependency hono to v3.11.3

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export { nanoid } from 'https://esm.sh/nanoid@4.0.0/async'
-export type { MiddlewareHandler, Context } from 'https://deno.land/x/hono@v3.5.8/mod.ts'
-export { getCookie, setCookie } from 'https://deno.land/x/hono@v3.5.8/helper/cookie/index.ts'
-export type { CookieOptions } from 'https://deno.land/x/hono@v3.5.8/utils/cookie.ts'
+export type { MiddlewareHandler, Context } from 'https://deno.land/x/hono@v3.11.3/mod.ts'
+export { getCookie, setCookie } from 'https://deno.land/x/hono@v3.11.3/helper/cookie/index.ts'
+export type { CookieOptions } from 'https://deno.land/x/hono@v3.11.3/utils/cookie.ts'
 export * as Iron from 'https://esm.sh/iron-webcrypto@0.10.1'


### PR DESCRIPTION
Hi

Here is a PR to test if this lib is still compatible with with hono now a days.
Locally I have an issue with mismatching Context so this pr might resolve it by ensuring that this lib is using the same hono latest version