### PR TITLE
fix some deno lint warnings

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4
@@ -83,7 +83,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4
@@ -107,7 +107,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4
@@ -139,7 +139,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4
@@ -170,7 +170,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4
@@ -198,7 +198,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.36.4

--- a/src/Crypto.ts
+++ b/src/Crypto.ts
@@ -1,6 +1,6 @@
 import { Iron } from '../deps.ts'
 
-export async function encrypt(password: string, payload: Object | string) {
+export async function encrypt(password: string, payload: object | string) {
   return await Iron.seal(globalThis.crypto, payload, password, Iron.defaults)
 }
 

--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -1,5 +1,5 @@
 import { nanoid } from '../deps.ts'
-import { MiddlewareHandler, Context, getCookie, setCookie } from '../deps.ts'
+import { MiddlewareHandler, getCookie, setCookie } from '../deps.ts'
 import Store from './store/Store.ts'
 import CookieStore from './store/CookieStore.ts'
 import { Session, SessionData, encrypt, decrypt } from '../mod.ts'
@@ -37,7 +37,7 @@ export function sessionMiddleware(options: SessionOptions) {
 
   const middleware: MiddlewareHandler = async (c, next) => {
     const session = new Session
-    let sid: string = ''
+    let sid = ''
     let session_data: SessionData | null | undefined
     let createNewSession = false
 

--- a/src/store/CookieStore.ts
+++ b/src/store/CookieStore.ts
@@ -1,5 +1,5 @@
 import { Context, getCookie, setCookie, CookieOptions } from '../../deps.ts'
-import { encrypt, decrypt, SessionData, Session } from '../../mod.ts'
+import { encrypt, decrypt, SessionData } from '../../mod.ts'
 
 interface CookieStoreOptions {
   encryptionKey?: string | null,

--- a/src/store/deno/DenoKvStore.ts
+++ b/src/store/deno/DenoKvStore.ts
@@ -11,7 +11,7 @@ export class DenoKvStore implements Store {
   }
 
   async getSessionById(sessionId: string) {
-    let session = (await this.kv.get([this.collectionName, sessionId])).value
+    const session = (await this.kv.get([this.collectionName, sessionId])).value
     return session as SessionData
   }
 

--- a/test/deno/MakeStore.ts
+++ b/test/deno/MakeStore.ts
@@ -13,14 +13,16 @@ export async function MakeDenoStore(storeDriver: string | undefined): Promise<St
     case 'cookie':
       store = new CookieStore()
       break
-    case 'kv':
+    case 'kv': {
       const kv = await Deno.openKv('./tmp/sessions')
       store = new DenoKvStore(kv)
       break
-    case 'sqlite':
+    }
+    case 'sqlite': {
       const sqlite = new DB('./tmp/sessions.sqlite')
       store = new DenoSqliteStore(sqlite)
       break
+    }
     default:
       store = new MemoryStore()
       break

--- a/test/node/package-lock.json
+++ b/test/node/package-lock.json
@@ -10,15 +10,14 @@
         "hono-sessions": "../../npm"
       },
       "devDependencies": {
-        "tsx": "^3.12.2"
+        "tsx": "^3.14.0"
       }
     },
     "../../npm": {
       "name": "hono-sessions",
-      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "hono": "3.5.8",
+        "hono": "3.12.7",
         "iron-webcrypto": "0.10.1",
         "nanoid": "4.0.0"
       }

--- a/test/node/package.json
+++ b/test/node/package.json
@@ -8,6 +8,6 @@
     "hono-sessions": "../../npm"
   },
   "devDependencies": {
-    "tsx": "^3.12.2"
+    "tsx": "^3.14.0"
   }
 }


### PR DESCRIPTION
Fixed some deno lint warnings.

I am new to typescript so I am not sure if the `Object` in `Crypto.ts` really is a typo or if it has some other meaning. Please check. 

Other changes, I think, are straightforward.