### PR TITLE
Optimize session deletion, recreation, and persistence

### DIFF
--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -100,18 +100,52 @@ export function sessionMiddleware(options: SessionOptions) {
 
     await next()
 
-    if (c.get('session_key_rotation') === true && !(store instanceof CookieStore)) {
-      await store.deleteSession(sid)
-      sid = await nanoid(21)
-      await store.createSession(sid, session.getCache())
-
-      setCookie(c, sessionCookieName, encryptionKey ? await encrypt(encryptionKey, sid) : sid, cookieOptions)
+    const shouldDelete = session.getCache()._delete;
+    const shouldRotateSessionKey = c.get("session_key_rotation") === true;
+    const storeIsCookieStore = store instanceof CookieStore;
+    
+    if (shouldDelete) {
+      store instanceof CookieStore
+        ? await store.deleteSession(c)
+        : await store.deleteSession(sid);
     }
 
-    store instanceof CookieStore ? await store.persistSessionData(c, session.getCache()) : await store.persistSessionData(sid, session.getCache())
+    /*
+     * Only update session data if we didn't just delete it.
+     * If session key rotation is enabled and the store is not a CookieStore,
+     * we need to roate the session key by deleting the old session and creating a new one.
+     */
+    const shouldRecreateSessionForNonCookieStore =
+      !shouldDelete &&
+      !storeIsCookieStore &&
+      shouldRotateSessionKey;
 
-    if (session.getCache()._delete) {
-      store instanceof CookieStore ? await store.deleteSession(c) : await store.deleteSession(sid)
+    if (shouldRecreateSessionForNonCookieStore) {
+      await store.deleteSession(sid);
+      sid = await nanoid(21);
+      await store.createSession(sid, session.getCache());
+
+      setCookie(
+        c,
+        sessionCookieName,
+        encryptionKey ? await encrypt(encryptionKey, sid) : sid,
+        cookieOptions
+      );
+    }
+
+    /*
+     * We skip session data persistence if it was just deleted.
+     * Only persist if we didn't just rotate the session key,
+     * or the store is a CookieStore (which does not have its session key rotated)
+     */
+    const shouldPersistSession =
+      !shouldDelete &&
+      (shouldRotateSessionKey || !storeIsCookieStore);
+
+    if (shouldPersistSession) {
+      store instanceof CookieStore
+        ? await store.persistSessionData(c, session.getCache())
+        : await store.persistSessionData(sid, session.getCache());
     }
   }
 

--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -140,7 +140,7 @@ export function sessionMiddleware(options: SessionOptions) {
      */
     const shouldPersistSession =
       !shouldDelete &&
-      (shouldRotateSessionKey || !storeIsCookieStore);
+      (!shouldRotateSessionKey || storeIsCookieStore);
 
     if (shouldPersistSession) {
       store instanceof CookieStore

--- a/test/bun/README.md
+++ b/test/bun/README.md
@@ -1,6 +1,11 @@
 ```
 bun install
-bun run dev
+
+# run using cookie store
+bun run dev:cookie
+
+# run using sqlite store
+bun run dev:sqlite
 ```
 
 ```

--- a/test/bun/package.json
+++ b/test/bun/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "dev": "bun run --hot src/index.ts"
+    "dev:cookie": "bun run --hot src/test_cookie.ts",
+    "dev:sqlite": "bun run --hot src/test_sqlite.ts"
   },
   "dependencies": {
     "hono": "3.12.8",


### PR DESCRIPTION
This work optimizes control flow by only rotating the session key or persisting data if the session is not deleted. The flow before this work would recreate the session key/persist session data every time, even if it would end up being deleted. This is important if storing the session in a database, as that means there is at least one additional round trip. For larger systems this could mean cutting the number of database interactions in half.

Tangential, the `bun dev` script has been split into two to reflect the two types of servers you can run.

Before merging I would love it if someone else could test this as well. Not being overly familiar with the library and there being no unit tests makes me nervous I missed something 😅 